### PR TITLE
opx-nas-l2 sync - 3.0.0-dev2 sync

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-l2], [1.21.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-l2], [1.22.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+opx-nas-l2 (1.22.0) unstable; urgency=medium
+
+  * Bugfix: Multicast Grp ID for a route is updated correctly when routes move from NULL OIF to OIFs. 
+  * Update: Added support of non-OIF multicast group
+  * Bugfix: Multicast traffic should not be forwarded to all the ports in the VLAN in MLD
+  * Update: L2MC support 
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 9 Jul 2018 14:38:23 -0800
+
 opx-nas-l2 (1.21.0) unstable; urgency=medium
 
   * Update: Support for setting multicast lookup key in VLAN

--- a/inc/opx/nas_mc_util.h
+++ b/inc/opx/nas_mc_util.h
@@ -50,9 +50,11 @@ void nas_mc_change_snooping_status(mc_event_type_t req_type, hal_vlan_id_t vlan_
 void nas_mc_add_mrouter(mc_event_type_t req_type, hal_vlan_id_t vlan_id, hal_ifindex_t ifindex);
 void nas_mc_del_mrouter(mc_event_type_t req_type, hal_vlan_id_t vlan_id, hal_ifindex_t ifindex);
 void nas_mc_add_route(mc_event_type_t req_type, hal_vlan_id_t vlan_id,
-                      hal_ip_addr_t group_addr, bool is_xg, hal_ip_addr_t src_addr, hal_ifindex_t ifindex);
+                      hal_ip_addr_t group_addr, bool is_xg, hal_ip_addr_t src_addr, bool have_ifindex,
+                      hal_ifindex_t ifindex);
 void nas_mc_del_route(mc_event_type_t req_type, hal_vlan_id_t vlan_id,
-                      hal_ip_addr_t group_addr, bool is_xg, hal_ip_addr_t src_addr, hal_ifindex_t ifindex);
+                      hal_ip_addr_t group_addr, bool is_xg, hal_ip_addr_t src_addr, bool have_ifindex,
+                      hal_ifindex_t ifindex);
 void nas_mc_cleanup_vlan_member(hal_vlan_id_t vlan_id, hal_ifindex_t ifindex);
 void nas_mc_cleanup_interface(hal_ifindex_t ifindex);
 void nas_mc_cleanup_vlan(hal_vlan_id_t vlan_id);

--- a/src/mcast_snooping/nas_mc_cps.cpp
+++ b/src/mcast_snooping/nas_mc_cps.cpp
@@ -167,9 +167,8 @@ static bool nas_mc_route_handler(mc_event_type_t evt_type, hal_vlan_id_t vid, bo
                 }
             }
         }
-        if (!addr_found || !if_found) {
-            NAS_MC_LOG_ERR("NAS-MC-CPS", "Could not find mandatory attributes: %s %s",
-                           addr_found ? "" : "GROUP_IP", if_found ? "" : "INTERFACE");
+        if (!addr_found) {
+            NAS_MC_LOG_ERR("NAS-MC-CPS", "Could not find mandatory attribute GROUP_IP");
             return false;
         }
         bool is_xg = src_ip_list.empty();
@@ -188,9 +187,9 @@ static bool nas_mc_route_handler(mc_event_type_t evt_type, hal_vlan_id_t vid, bo
             NAS_MC_LOG_INFO("NAS-MC-CPS", "%s multicast route entry: VID %d IP %s SRC %s IF %d",
                              add ? "Add" : "Delete", vid, ip_str, src_ip_str, ifindex);
             if (add) {
-                nas_mc_add_route(evt_type, vid, group_ip, is_xg, src_ip, ifindex);
+                nas_mc_add_route(evt_type, vid, group_ip, is_xg, src_ip, if_found, ifindex);
             } else {
-                nas_mc_del_route(evt_type, vid, group_ip, is_xg, src_ip, ifindex);
+                nas_mc_del_route(evt_type, vid, group_ip, is_xg, src_ip, if_found, ifindex);
             }
         }
     }


### PR DESCRIPTION
  * Bugfix: Multicast Grp ID for a route is updated correctly when routes move from NULL OIF to OIFs.
  * Update: Added support of non-OIF multicast group
  * Bugfix: Multicast traffic should not be forwarded to all the ports in the VLAN in MLD on S5148F
  * Update: L2MC support on S5148F

Signed-off-by: Rakesh Datta <rakesh.datta6@gmail.com>