### PR TITLE
Feat: OPX3.1-dev1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-l2], [1.22.0+opx2], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-l2], [1.22.0+opx3], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+opx-nas-l2 (1.22.0+opx3) unstable; urgency=medium
+
+  * Feature: Static L2 VxLAN Support
+  * Bugfix: port-vlan-subport deletion was not handled
+  * Bugfix: Mac changes to support mac learned from untagged_attached vlan members and untagged
+            virtual network members
+  * Bugfix: Add lock to handle NPU MAC events
+  * Update: Check for tunnel ID 0 for tunnel creation/deletion event
+  * Update: Handle vlan member port add to program stg state
+  * Update: Add IPv6 Extended routes handler code
+  * Update: For non-OIF entry, restore to default group ID after mrouter port is deleted
+  * Update: Prevent publishing VLAN id for 1d remote mac
+  * Update: Return code to trigger VLAN key lookup to accommodate initial case when snooping status is same
+  * Update: Update: Renaming nas_ut_framework to nas_common_utils
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 06 Nov 2018 14:38:23 -0800
+
 opx-nas-l2 (1.22.0+opx2) unstable; urgency=medium
 
   * Bugfix: Fix binary name of opx-nas process in opx-switch-log utility
@@ -7,20 +24,20 @@ opx-nas-l2 (1.22.0+opx2) unstable; urgency=medium
 
 opx-nas-l2 (1.22.0+opx1) unstable; urgency=medium
 
-  * Bugfix: RSTP BLK port’s status is set as “forwarding” in kernel for newly created vlans; 
+  * Bugfix: RSTP BLK port’s status is set as “forwarding” in kernel for newly created vlans;
             control traffic gets soft flooded.
   * Update: Support IPv6 extended prefix installation.
-  * Update: (L2MC support) SG entry due to exclude join points to an invalid L2MC 
+  * Update: (L2MC support) SG entry due to exclude join points to an invalid L2MC
             after removing mrouter port from the VLAN.
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 10 Aug 2018 14:38:23 -0800
 
 opx-nas-l2 (1.22.0) unstable; urgency=medium
 
-  * Bugfix: Multicast Grp ID for a route is updated correctly when routes move from NULL OIF to OIFs. 
+  * Bugfix: Multicast Grp ID for a route is updated correctly when routes move from NULL OIF to OIFs.
   * Update: Added support of non-OIF multicast group
   * Bugfix: Multicast traffic should not be forwarded to all the ports in the VLAN in MLD
-  * Update: L2MC support 
+  * Update: L2MC support
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 9 Jul 2018 14:38:23 -0800
 
@@ -38,7 +55,7 @@ opx-nas-l2 (1.17.0+opx3) unstable; urgency=medium
   * Update: Add compiler/linker hardening flags
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 17 May 2018 14:38:23 -0800
- 
+
 opx-nas-l2 (1.17.0+opx2) unstable; urgency=medium
 
   * Update: Support for printing of list data type
@@ -70,7 +87,7 @@ opx-nas-l2 (1.17.0) unstable; urgency=medium
   * Bugfix: Removed duplicate function to convert name to ifindex
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 13 Dec 2017 14:38:23 -0800
- 
+
 opx-nas-l2 (1.14.0) unstable; urgency=medium
 
   * Update: Pass ifname to update mac entry in kernel
@@ -94,7 +111,7 @@ opx-nas-l2 (1.12.0) unstable; urgency=medium
   * Update: Set the port state to blocking when port is deleted from LAG, or LAG is deleted
   * Update: Update/remove mac in kernel when mac is moved/aged in npu
   * Update: Implemented mac get from ndi
-  * Update: Updated the sflow script to accept ifname and ifindex for 
+  * Update: Updated the sflow script to accept ifname and ifindex for
   * Update: Miscellaneous performance improvements and optimizations
   * Feature: Added infra support from BASE for switch profile, uft mode, max ecmp
             based on "dell-switch-element.yang"
@@ -103,7 +120,7 @@ opx-nas-l2 (1.12.0) unstable; urgency=medium
             disable and also disable sampling using enable command with sampling rate of 0
   * Bugfix: Miscellaneous bug fixes
   * Cleanup: Miscellaneous cleanup
- 
+
  -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 20 Jun 2017 14:38:23 -0800
 
 opx-nas-l2 (1.0.1) unstable; urgency=medium

--- a/scripts/bin/cps_config_mac.py
+++ b/scripts/bin/cps_config_mac.py
@@ -13,19 +13,25 @@
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 
-import cps
-import os
 from cps_utils import *
-import sys
-import nas_os_utils
+import argparse
 
-set_action = {
-    "drop"      : "1",
-    "forward"   : "2",
-    "trap"      : "3",
-    "log"       : "4",
-    "default"   : "2"
-}
+ip_family_map = {
+                 "ipv4": 2,
+                  "ipv6" : 10
+                }
+
+flush_map = {
+                "port": 1,
+                "port-vlan": 2,
+                "vlan": 3,
+                "bridge" : 5,
+                "bridge-endpoint-ip" : 6,
+                "all" : 4,
+                "endpoint-ip" : 7,
+                "port-vlan-subport" : 8,
+                "port-bridge" : 9
+            }
 
 def commit(obj, op):
     l = []
@@ -34,230 +40,141 @@ def commit(obj, op):
     t = CPSTransaction(l)
     ret = t.commit()
     if ret:
-        print "success"
+        print "Success"
+    else:
+        print "Failed"
     return ret
 
 
-def usage():
-    print"\n\n cps_config_mac.py [create | set ] [mac <mac-address>] [port <port>] [vlan <vlan-id>] [static | dynamic]"
-    print"\n                          [configure-os]"
-    print"\n                          [action <drop | forward | trap | log | source_drop | default>]"
-    print"\n\n cps_config_mac.py delete [all] [vlan <vlanid>] [port <port>] [mac <mac-address>] [static | dynamic]"
-    print "\n               eg : cps_config_mac.py delete vlan 100 static "
-    print "\n                    cps_config_mac.py delete vlan 100 port e101-007-0 "
-    print "\n                    cps_config_mac.py delete static"
-    print"\n\n cps_config_mac.py show [vlan <vlanid>] [port <port>] [mac <mac-address>] [all][count] [static | dynamic]"
-    print"\n\n"
+def _create_1q_mac(args, parser):
 
-
-def create_mac_addr(macAddr, vlan, port, action,static,static_type,os_configure,op):
+    if not args.mac or not args.vlan or not args.iface:
+        parser.print_help()
+        return
 
     cps_utils.add_attr_type("base-mac/table/mac-address", "mac")
-    if not static_type:
-        static = 1
     obj = CPSObject('base-mac/table',
-                     data= {"switch-id" : 0, "mac-address" : macAddr,
-                       "vlan" : vlan,  "static" : static,  })
-    if port:
-        obj.add_attr("ifname",port)
-    if action:
-        obj.add_attr("actions",set_action[action])
-    if os_configure:
-        obj.add_attr("configure-os",os_configure)
+                     data= {"switch-id" : 0, "mac-address" : args.mac,
+                       "vlan" : args.vlan, "ifname":args.iface  })
+    if args.static:
+        obj.add_attr("static",args.static)
+    if args.conf_os or args.conf_os_only:
+        obj.add_attr("configure-os",1)
+    if args.conf_os_only:
+        obj.add_attr("configure-npu",0)
     print obj.get()
-    commit(obj, op)
-    return
+    return commit(obj, "create")
 
 
-def handle_count(vlan, port, mac_valid, mac, all, static, static_type):
-    get = []
-    get_obj = CPSObject("base-mac/query")
-    get_obj.add_attr_type("mac-address", "mac")
-    if (vlan != 0):
-        get_obj.add_attr("vlan", vlan)
-    if (port != 0):
-        index = nas_os_utils.if_nametoindex(port)
-        get_obj.add_attr("ifindex", index)
-    if (mac_valid == 1):
-        get_obj.add_attr("mac-address", mac)
-    if (static_type == 1):
-        get_obj.add_attr("static", static)
-    get_obj.add_attr("request-type", 4)
-    print get_obj.get()
-    if cps.get([get_obj.get()], get):
-        for i in get:
-            print_obj(i)
-            print "\n\n"
-    else:
-        print("\n no objects received")
+def _create_1d_mac(args,parser):
 
+    if not args.mac or not args.iface or not args.bridge:
+        parser.print_help()
+        return
 
-def handle_delete(vlan, port, mac_valid, mac, all, static, static_type):
-    obj = CPSObject("base-mac/table")
-    obj.add_attr_type("mac-address", "mac")
-    if (vlan != 0):
-        obj.add_attr("vlan", vlan)
-        obj.add_attr("request-type", 1)
-    if (port != 0):
-        index = nas_os_utils.if_nametoindex(port)
-        obj.add_attr("ifindex", index)
-        obj.add_attr("request-type", 3)
-    if (mac_valid == 1):
-        obj.add_attr("mac-address", mac)
-        obj.add_attr("request-type", 2)
-    if (all == 1):
-        obj.add_attr("request-type", 5)
-    if (static_type == 1):
-        obj.add_attr("static", static)
+    cps_utils.add_attr_type("base-mac/forwarding-table/mac-address", "mac")
+    obj = CPSObject('base-mac/forwarding-table',
+                     data= {"switch-id" : 0, "mac-address" : args.mac,
+                       "br-name" : args.bridge, "ifname":args.iface  })
 
+    if args.type == "1D-Local":
+        if not args.vlan:
+            parser.print_help()
+            return
+        else:
+            obj.add_attr("vlan",args.vlan)
+
+    if args.type == "1D-Remote":
+        if not args.ip or not args.af:
+            parser.print_help()
+            return
+        else:
+            obj.add_attr("base-mac/forwarding-table/endpoint-ip/addr-family",ip_family_map[args.af])
+            obj.add_attr_type("base-mac/forwarding-table/endpoint-ip/addr",args.af)
+            obj.add_attr("base-mac/forwarding-table/endpoint-ip/addr",args.ip)
+
+    if args.static:
+        obj.add_attr("static",args.static)
+    if args.conf_os or args.conf_os_only:
+        obj.add_attr("configure-os",1)
+    if args.conf_os_only:
+        obj.add_attr("configure-npu",0)
     print obj.get()
-    commit(obj, "delete")
-    return
+    return commit(obj, "create")
 
 
-def handle_show(vlan, port, mac_valid, mac, all, static, static_type):
-    get = []
-    get_obj = CPSObject("base-mac/query")
-    get_obj.add_attr_type("mac-address", "mac")
-    if (vlan != 0):
-        get_obj.add_attr("vlan", vlan)
-        get_obj.add_attr("request-type", 1)
-    if (port != 0):
-        index = nas_os_utils.if_nametoindex(port)
-        get_obj.add_attr("ifindex", index)
-        get_obj.add_attr("request-type", 3)
-    if (mac_valid == 1):
-        get_obj.add_attr("mac-address", mac)
-        get_obj.add_attr("request-type", 2)
-    if (static_type == 1):
-        get_obj.add_attr("static", static)
-    print get_obj.get()
-    print("\n calling get \n")
-    if cps.get([get_obj.get()], get):
-        print("\n get returned true\n")
-        for i in get:
-            print_obj(i)
-            print "\n\n"
-    else:
-        print("\n no objects received")
+def _delete_mac(args,parser):
+    cps_utils.add_attr_type("base-mac/table/mac-address", "mac")
+    cps_utils.add_attr_type("base-mac/forwarding-table/mac-address", "mac")
+    if args.del_type == "single":
+        if args.type == "1Q":
+            obj = CPSObject('base-mac/table', data= { "mac-address" : args.mac, "vlan" : args.vlan})
+            return commit(obj, "delete")
+        else:
+            obj = CPSObject('base-mac/forwarding-table', data= {"mac-address" : args.mac,"br-name":args.bridge})
+            if args.af:
+                obj.add_attr("base-mac/forwarding-table/endpoint-ip/addr-family",ip_family_map[args.af])
+                obj.add_attr_type("base-mac/forwarding-table/endpoint-ip/addr",args.af)
+                obj.add_attr("base-mac/forwarding-table/endpoint-ip/addr",args.ip)
+            print obj.get()
+            return commit(obj, "delete")
+
+
+    obj = CPSObject('base-mac/flush')
+    l = ["base-mac/flush/input/filter","0","flush-type"]
+    obj.add_embed_attr(l,flush_map[args.del_type])
+    if (args.del_type in ["port", "port-vlan" ,"port-vlan-subport", "port-bridge"]) and args.iface:
+        l[2]="ifname"
+        obj.add_embed_attr(l,args.iface)
+        print obj
+    if (args.del_type == "vlan" or args.del_type == "port-vlan") and args.vlan:
+        l[2]="vlan"
+        obj.add_embed_attr(l,args.vlan)
+    if (args.del_type == "bridge" or args.del_type == "port-bridge") and args.bridge:
+        l[2]="br-name"
+        obj.add_embed_attr(l,args.bridge)
+        print obj
+    if (args.del_type == "bridge-ednpoint-ip" or args.del_type == "endpoint-ip") and args.af and args.ip:
+        l[2]="endpoint-ip/addr-family"
+        obj.add_embed_attr(l,ip_family_map[args.af])
+        obj.add_attr_type("base-mac/flush/input/filter/endpoint-ip/addr",args.af)
+        l[2]="endpoint-ip/addr"
+        obj.add_embed_attr(l,args.ip)
+    print obj.get()
+    return commit(obj, 'rpc')
 
 
 if __name__ == '__main__':
-    vlan_id = port = static = count = all = mac_valid = show = static_type = os_configure = 0
-    mac = ""
-    action = 0
-    if len(sys.argv) == 1:
-        usage()
-    else:
-        if sys.argv[1] == "create" or sys.argv[1]=="set":
-           arglen = len(sys.argv)
-           if arglen < 7:
-              usage()
-           else:
-              i = 2
-              while (i < arglen):
-                  if (sys.argv[i] == "mac"):
-                      i = i+1
-                      mac = sys.argv[i]
-                  elif (sys.argv[i] == "port"):
-                      i = i+1
-                      port = sys.argv[i]
-                  elif (sys.argv[i] == "vlan"):
-                      i = i+1
-                      vlan_id = sys.argv[i]
-                  elif (sys.argv[i] == "action"):
-                      i = i+1
-                      action = sys.argv[i]
-                  elif (sys.argv[i] == "static"):
-                      static = 1
-                      static_type = 1
-                  elif (sys.argv[i] == "dynamic"):
-                      static = 0
-                      static_type = 1
-                  elif (sys.argv[i] == "configure-os"):
-                      os_configure = 1
-                  i = i+1
-              create_mac_addr(mac, vlan_id, port, action,static,static_type,os_configure,sys.argv[1])
-        elif (sys.argv[1] in ["show", "delete"]):
-            print("len = ", len(sys.argv))
-            print("command : ", sys.argv[1])
-            arglen = len(sys.argv)
-            if (sys.argv[1] == "show"):
-                show = 1
-            if (sys.argv[1] == "delete"):
-                delete = 1
-            i = 2
-            while (i < arglen):
-                print("\n iteration i", i)
-                if (arglen == 2):
-                     # show all  static and dynamic
-                    static_type = 0
-                elif (sys.argv[i] == "vlan"):
-                    i = i + 1
-                    if (i > arglen):
-                        print"\n\n Please reenter with vlan id"
-                    vlan_id = sys.argv[i]
-                elif (sys.argv[i] == "port"):
-                    i = i + 1
-                    if (i > arglen):
-                        print"\n\n please reenter with port name"
-                    port = sys.argv[i]
-                elif (sys.argv[i] == "mac"):
-                    i = i + 1
-                    if (i > arglen):
-                        print"\n\n please enter mac address in a:b:c:d:e:f format"
-                    mac = sys.argv[i]
-                    mac_valid = 1
-                elif (sys.argv[i] == "all"):
-                    all = 1
-                elif (sys.argv[i] == "count"):
-                    count = 1
-                elif (sys.argv[i] == "static"):
-                    static = 1
-                    static_type = 1
-                elif (sys.argv[i] == "dynamic"):
-                    static = 0
-                    static_type = 1
-                i = i + 1
-            print(
-                "\n\n show vlan with vlan port mac all static ",
-                vlan_id,
-                port,
-                mac_valid,
-                mac,
-                all,
-                count,
-                static)
-            if (count):
-                print("\n count command")
-                handle_count(
-                    vlan_id,
-                    port,
-                    mac_valid,
-                    mac,
-                    all,
-                    static,
-                    static_type)
+    parser = argparse.ArgumentParser(description = 'Tool for FDB management')
+    parser.add_argument('-o', '--oper', choices = ['create', 'delete', 'update'])
+    parser.add_argument('-m','--mac',help=" MAC address")
+    parser.add_argument('-i','--iface', help = 'Name of interface')
+    parser.add_argument('-b','--bridge', help = 'Name of Bridge')
+    parser.add_argument('-t','--type',choices = ["1Q","1D-Local","1D-Remote"], help = 'Type of MAC entry')
+    parser.add_argument('--ip', help = 'IP address when type is 1D-Remote')
+    parser.add_argument('--af', choices = ["ipv4","ipv6"],help = 'IP address family when type is 1D-Remote')
+    parser.add_argument('-v','--vlan',type = int,  help = 'vlan id')
+    parser.add_argument('-s','--static',action='store_true',  help = 'Static FDB entry')
+    parser.add_argument('--conf-os',action='store_true',  help = 'Configure FDB entry in OS and in NPU')
+    parser.add_argument('--conf-os-only',action='store_true',  help = 'Configure FDB entry in OS only')
+    parser.add_argument('--del-type',choices = ["port","port-vlan","vlan","bridge","bridge-endpoint-ip","all",
+                                                "single","endpoint-ip","port-vlan-subport","port-bridge"],
+                        help = 'Delete entry type')
 
-            elif (show):
-                print("\n show command")
-                handle_show(
-                    vlan_id,
-                    port,
-                    mac_valid,
-                    mac,
-                    all,
-                    static,
-                    static_type)
-            elif (delete):
-                print("\n delete command")
-                handle_delete(
-                    vlan_id,
-                    port,
-                    mac_valid,
-                    mac,
-                    all,
-                    static,
-                    static_type)
+    args = parser.parse_args()
+
+    if not args.type:
+        args.type = "1Q"
+
+    if args.oper == 'create':
+        if args.type == "1Q":
+            _create_1q_mac(args,parser)
         else:
-            usage()
+            _create_1d_mac(args,parser)
+
+    elif args.oper == 'update':
+        _update_mac(args,parser)
+
+    elif args.oper == 'delete':
+        _delete_mac(args,parser)
+

--- a/scripts/bin/cps_config_mirror.py
+++ b/scripts/bin/cps_config_mirror.py
@@ -17,7 +17,7 @@
 
 import cps_utils
 import nas_os_utils
-import nas_ut_framework as nas_ut
+import nas_common_utils as nas_common
 import sys
 
 mirror_type = {"span":"1","rspan":"2"}
@@ -29,7 +29,7 @@ def nas_mirror_op(op, data_dict,commit=True):
         module="base-mirror/entry",
         data=data_dict)
     if commit:
-        nas_ut.get_cb_method(op)(obj)
+        nas_common.get_cb_method(op)(obj)
     else:
         return obj
 
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         elif sys.argv[2] =="rspan" and len(sys.argv) == 6:
             usage()
         print obj.get()
-        nas_ut.get_cb_method("create")(obj)
+        nas_common.get_cb_method("create")(obj)
 
     elif sys.argv[1] == "delete" and len(sys.argv) == 3:
         nas_mirror_op("delete", {"id": sys.argv[2]})
@@ -78,7 +78,7 @@ if __name__ == '__main__':
         obj = nas_mirror_op("set", {"id": sys.argv[2]},False)
         nas_mirror_add_source(obj,sys.argv[3],sys.argv[4])
         print obj.get()
-        nas_ut.get_cb_method("set")(obj)
+        nas_common.get_cb_method("set")(obj)
 
     elif sys.argv[1] == "set_dest" and len(sys.argv) == 4:
         nas_mirror_op("set", {"id": sys.argv[2],

--- a/scripts/bin/cps_config_sflow
+++ b/scripts/bin/cps_config_sflow
@@ -15,7 +15,7 @@
 import sys
 import nas_sflow_utils
 import cps_object
-import nas_ut_framework as nas_ut
+import nas_common_utils as nas_common
 import nas_os_utils
 import  cps
 
@@ -58,7 +58,7 @@ def nas_sflow_op(op, data_dict):
             for i in get:
                nas_sflow_utils.print_obj(i)
     else:
-        nas_ut.get_cb_method(op)(obj)
+        nas_common.get_cb_method(op)(obj)
 
 
 def usage():

--- a/scripts/bin/cps_config_stg.py
+++ b/scripts/bin/cps_config_stg.py
@@ -16,7 +16,7 @@
 import sys
 import nas_stg_utils
 import cps_object
-import nas_ut_framework as nas_ut
+import nas_common_utils as nas_common
 import nas_os_utils
 
 port_state_map = {
@@ -33,7 +33,7 @@ def nas_stg_op(op, data_dict, type):
         module=nas_stg_utils.get_stg_keys()[int(type)],
         data=data_dict)
     obj.add_attr("base-stg/entry/switch-id", "0")
-    nas_ut.get_cb_method(op)(obj)
+    nas_common.get_cb_method(op)(obj)
 
 
 def set_stp_state(stg_id, interface, state):
@@ -43,7 +43,7 @@ def set_stp_state(stg_id, interface, state):
     obj.add_embed_attr(el, nas_os_utils.if_nametoindex(interface))
     el[2] = "state"
     obj.add_embed_attr(el, port_state_map[state])
-    nas_ut.get_cb_method("set")(obj)
+    nas_common.get_cb_method("set")(obj)
 
 
 def usage():

--- a/scripts/bin/opx-config-switch
+++ b/scripts/bin/opx-config-switch
@@ -15,7 +15,7 @@
 
 import sys
 import nas_switch_utils
-import nas_ut_framework as nas_ut
+import nas_common_utils as nas_common
 
 
 def show_switch(args):
@@ -24,7 +24,7 @@ def show_switch(args):
 
 def set_switch_attrs(args):
     ch = nas_switch_utils.create_switch_set_op(args)
-    ret = nas_ut.get_cb_method("set")(ch)
+    ret = nas_common.get_cb_method("set")(ch)
     if (str(ret) == 'False'):
         print "Unable to set attribute, check the attr and the values"
 

--- a/scripts/bin/opx-switch-log
+++ b/scripts/bin/opx-switch-log
@@ -15,7 +15,7 @@
 
 import sys
 import cps_object
-import nas_ut_framework as nas_ut
+import nas_common_utils as nas_common
 import os
 import signal
 from subprocess import check_output
@@ -88,7 +88,7 @@ def parse_args(id, level):
 def nas_diag_set(data_dict):
     obj = cps_object.CPSObject(module="base-switch/set_log", data=data_dict)
     print obj.get()
-    nas_ut.get_cb_method("rpc")(obj)
+    nas_common.get_cb_method("rpc")(obj)
 
 def get_pid(name):
     return int(check_output(["pidof","-s",name]))

--- a/scripts/lib/python/nas_switch_utils.py
+++ b/scripts/lib/python/nas_switch_utils.py
@@ -63,11 +63,6 @@ def print_switch_uft_info(uft_data, switch_mode):
             value = cps_object.types.from_data(key, uft_data[mode][key])
             print key + ' = ' +  str(value)
 
-def list_to_str(key, list_data):
-    value = cps_object.types.from_data(key, list_data[0])
-    for i in list_data[1:]:
-        value = value + ',' + str(cps_object.types.from_data(key, i))
-    return value
 
 def print_switch_details(args):
     switch_mode=['base-switch/switching-entities/switching-entity/switch-mode']
@@ -76,8 +71,6 @@ def print_switch_details(args):
         if isinstance(data, dict):
             ''' UFT mode information are stored as a dictionary '''
             print_switch_uft_info(data, switch_mode)
-        elif isinstance(data, list):
-            print key + ' = ' + list_to_str(key, data)
         else:
             value = cps_object.types.from_data(key,data)
             if key in switch_mode:

--- a/src/mac/nas_mac_api.cpp
+++ b/src/mac/nas_mac_api.cpp
@@ -23,15 +23,57 @@
 #include "std_error_codes.h"
 #include "cps_api_events.h"
 #include "cps_api_operation.h"
+#include "cps_class_map.h"
 #include "hal_if_mapping.h"
 #include "nas_ndi_mac.h"
 #include "nas_base_utils.h"
 #include "nas_linux_l2.h"
 #include "nas_if_utils.h"
+#include "dell-base-interface-common.h"
+#include "ds_common_types.h"
+#include "std_ip_utils.h"
+#include "std_utils.h"
 
-#include <unordered_set>
+#include <string>
+#include <map>
+#include <set>
 #include <stdlib.h>
+#include <mutex>
 
+typedef std::list<nas_mac_entry_t>nas_mac_list;
+typedef std::unordered_set<std::string>nas_mac_str_list;
+
+
+static std::recursive_mutex _vxlan_mtx;
+static std::mutex _bridge_mtx;
+
+struct vni_rem_ip_hash{
+    std::size_t operator()(const vni_rem_ip_t & k) const{
+
+        return ((std::hash<std::string>{}(k.ip)
+                 ^ (std::hash<int>{}(k.br_index) << 1)) >> 1);
+    }
+
+};
+
+static auto vxlan_pending_macs = * new std::unordered_map<vni_rem_ip_t, nas_mac_list,vni_rem_ip_hash> ;
+static auto vxlan_remote_macs = * new std::unordered_map<vni_rem_ip_t, nas_mac_str_list,vni_rem_ip_hash> ;
+static auto known_rem_ips = * new std::unordered_set<vni_rem_ip_t,vni_rem_ip_hash> ;
+static auto bridge_map = * new std::unordered_map<hal_ifindex_t, hal_ifindex_t> ;
+static auto remote_ip_event_mask = * new std::unordered_set<vni_rem_ip_t,vni_rem_ip_hash> ;
+static auto vxlan_bridge_map = * new std::unordered_map<hal_ifindex_t, hal_ifindex_t>;
+static auto tunnel_endpoint_map = * new std::unordered_map<vni_rem_ip_t,ndi_obj_id_t,vni_rem_ip_hash>;
+static auto tunnel_id_to_vtep_map = * new std::unordered_map<ndi_obj_id_t,std::string>;
+static const size_t mac_addr_str_len = 20;
+
+struct _remote_pending_entry {
+    nas_mac_entry_t entry;
+    nas::attr_set_t attrs;
+    cps_api_operation_types_t op;
+};
+using _remote_entry_list = std::list<_remote_pending_entry>;
+
+static auto _remote_pending_entry_map = * new std::unordered_map<hal_ifindex_t, _remote_entry_list>;
 
 static bool nas_mac_entry_action_supported(BASE_MAC_PACKET_ACTION_t action)
 {
@@ -41,17 +83,112 @@ static bool nas_mac_entry_action_supported(BASE_MAC_PACKET_ACTION_t action)
             action == BASE_MAC_PACKET_ACTION_DROP);
 }
 
+static std::unordered_map <cps_api_operation_types_t, const char *> _oper_type = {
+    {cps_api_oper_CREATE, "CREATE"},
+    {cps_api_oper_SET, "UPDATE"},
+    {cps_api_oper_DELETE, "DELETE"},
+};
+static bool nas_mac_get_bridge_from_vtep(hal_ifindex_t & vtep_index, hal_ifindex_t & br_index){
+    std::lock_guard<std::mutex> _lk(_bridge_mtx);
+    auto it = vxlan_bridge_map.find(vtep_index);
+    if(it != vxlan_bridge_map.end()){
+        br_index = it->second;
+        return true;
+    }
 
+    return false;
+}
+
+bool nas_mac_get_vtep_name_from_tunnel_id(ndi_obj_id_t id, std::string & s){
+    std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+    auto it = tunnel_id_to_vtep_map.find(id);
+    if(it == tunnel_id_to_vtep_map.end()){
+        return false;
+    }
+
+    s = it->second;
+    return true;
+}
+
+static bool nas_mac_validate_params(nas::attr_set_t & attrs, cps_api_operation_types_t op){
+
+    if(op == cps_api_oper_DELETE){
+        return true;
+    }
+    if (!attrs.contains(BASE_MAC_TABLE_MAC_ADDRESS)){
+        return false;
+    }
+
+    if( op == cps_api_oper_CREATE){
+
+        if (attrs.contains(BASE_MAC_FORWARDING_TABLE_BR_NAME) && attrs.contains(BASE_MAC_TABLE_IFINDEX)){
+            if((attrs.contains(BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP) &&
+               attrs.contains(BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP_ADDR_FAMILY)) ||
+                (attrs.contains(BASE_MAC_TABLE_VLAN) ))
+                return true;
+        }else if(attrs.contains(BASE_MAC_TABLE_VLAN) &&
+                attrs.contains(BASE_MAC_TABLE_IFINDEX)){
+            return true;
+        }
+    } else if (op == cps_api_oper_SET) {
+        if (attrs.contains(BASE_MAC_TABLE_VLAN) || attrs.contains(BASE_MAC_FORWARDING_TABLE_BR_NAME)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static void nas_mac_get_str_from_mac(hal_mac_addr_t & mac_addr, std::string & s){
+
+    char mac_addr_str[mac_addr_str_len];
+    memset(mac_addr_str,0,sizeof(mac_addr_str));
+    std_mac_to_string(&mac_addr,mac_addr_str,mac_addr_str_len);
+    s = std::string(mac_addr_str);
+}
+
+
+void nas_mac_log_entry(nas_mac_entry_t *entry) {
+
+    const char *mac = (const char *)&(entry->entry_key.mac_addr[0]);
+    if ( entry->entry_type == NDI_MAC_ENTRY_TYPE_1D_LOCAL) {
+        EV_LOGGING(L2MAC, INFO,"NAS-MAC",
+          " Entry Type: 1D, Bridge Index: %d, Vlan Id: %d, Interface Index: %d,"
+         " MAC Address %02x:%02x:%02x:%02x:%02x:%02x",
+                        entry->bridge_ifindex, entry->entry_key.vlan_id, entry->ifindex,
+                        mac[0],mac[1],mac[2], mac[3],mac[4],mac[5]);
+    } else if ( entry->entry_type == NDI_MAC_ENTRY_TYPE_1D_REMOTE) {
+        EV_LOGGING(L2MAC, INFO,"NAS-MAC"," Entry Type: 1D Remote , Bridge Index: %d, Vlan Id: %d, Remote IP: %d "
+                                " MAC Address: %02x:%02x:%02x:%02x:%02x:%02x",
+                        entry->bridge_ifindex, entry->entry_key.vlan_id, entry->ifindex,
+                        mac[0],mac[1],mac[2], mac[3],mac[4],mac[5]);
+    } else if ( entry->entry_type == NDI_MAC_ENTRY_TYPE_1Q){
+        EV_LOGGING(L2MAC, INFO,"NAS-MAC"," Entry Type: 1Q, Vlan Id: %d, Interface Index: %d, "
+               " MAC Address %02x:%02x:%02x:%02x:%02x:%02x",
+                        entry->entry_key.vlan_id, entry->ifindex,
+                        mac[0],mac[1],mac[2], mac[3],mac[4],mac[5]);
+    }
+
+}
 static t_std_error nas_mac_obj_to_entry (cps_api_object_t obj, nas_mac_entry_t *entry) {
 
     cps_api_object_it_t it;
-    bool valid_param_set[4] = {false, false, false, false};
     cps_api_operation_types_t op = cps_api_object_type_operation(cps_api_object_key(obj));
 
-    memset(entry, 0, sizeof(nas_mac_entry_t));
     entry->npu_configured = true;
     entry->os_configured =false;
     entry->is_static = false;
+    entry->pkt_action = BASE_MAC_PACKET_ACTION_FORWARD;
+    entry->entry_type = NDI_MAC_ENTRY_TYPE_1Q;
+    entry->cache = false;
+    nas::attr_set_t attrs;
+
+    cps_api_object_attr_t _1d_attr;
+    _1d_attr = cps_api_object_attr_get(obj, BASE_MAC_FORWARDING_TABLE_MAC_ADDRESS);
+    if(_1d_attr){
+        entry->entry_type = NDI_MAC_ENTRY_TYPE_1D_LOCAL;
+    }
+
 
     cps_api_object_it_begin(obj,&it);
 
@@ -60,19 +197,19 @@ static t_std_error nas_mac_obj_to_entry (cps_api_object_t obj, nas_mac_entry_t *
         switch ((int) cps_api_object_attr_id(it.attr)) {
 
             case BASE_MAC_TABLE_VLAN:
-            case BASE_MAC_QUERY_VLAN:
+            case BASE_MAC_FORWARDING_TABLE_VLAN:
                 entry->entry_key.vlan_id = cps_api_object_attr_data_u16(it.attr);
-                valid_param_set[1] = true;
+                attrs.add(BASE_MAC_TABLE_VLAN);
                 break;
 
             case BASE_MAC_TABLE_IFINDEX:
-            case BASE_MAC_QUERY_IFINDEX:
+            case BASE_MAC_FORWARDING_TABLE_IFINDEX:
                 entry->ifindex = cps_api_object_attr_data_u32(it.attr);
-                valid_param_set[2] = true;
+                attrs.add(BASE_MAC_TABLE_IFINDEX);
                 break;
 
             case BASE_MAC_TABLE_IFNAME:
-            case BASE_MAC_QUERY_IFNAME:
+            case BASE_MAC_FORWARDING_TABLE_IFNAME:
             {
                 const char * name = (const char *)cps_api_object_attr_data_bin(it.attr);
                 interface_ctrl_t i;
@@ -85,11 +222,11 @@ static t_std_error nas_mac_obj_to_entry (cps_api_object_t obj, nas_mac_entry_t *
                         return STD_ERR(MAC,FAIL,0);
                 }
                 entry->ifindex = i.if_index;
-                valid_param_set[2] = true;
+                attrs.add(BASE_MAC_TABLE_IFINDEX);
                 break;
             }
             case BASE_MAC_TABLE_MAC_ADDRESS:
-            case BASE_MAC_QUERY_MAC_ADDRESS:
+            case BASE_MAC_FORWARDING_TABLE_MAC_ADDRESS:
             {
                 size_t mac_len = cps_api_object_attr_len(it.attr);
                 if (mac_len < sizeof(hal_mac_addr_t)) {
@@ -98,11 +235,12 @@ static t_std_error nas_mac_obj_to_entry (cps_api_object_t obj, nas_mac_entry_t *
                 }
                 memcpy(entry->entry_key.mac_addr, cps_api_object_attr_data_bin(it.attr),
                         sizeof(hal_mac_addr_t));
-                valid_param_set[3] = true;
+               attrs.add(BASE_MAC_TABLE_MAC_ADDRESS);
                 break;
             }
 
             case BASE_MAC_TABLE_ACTIONS:
+            case BASE_MAC_FORWARDING_TABLE_ACTIONS:
             {
                 BASE_MAC_PACKET_ACTION_t pkt_action = (BASE_MAC_PACKET_ACTION_t)
                                                     cps_api_object_attr_data_u32(it.attr);
@@ -110,23 +248,88 @@ static t_std_error nas_mac_obj_to_entry (cps_api_object_t obj, nas_mac_entry_t *
                     NAS_MAC_LOG(ERR,  "Unsupported action type: %d", entry->pkt_action);
                     return STD_ERR(MAC,CFG,0);
                 }
-                else{
-                    valid_param_set[0] = true;
-                    entry->pkt_action = pkt_action;
-                }
+                entry->pkt_action = pkt_action;
+
                 break;
             }
-            case BASE_MAC_QUERY_STATIC:
             case BASE_MAC_TABLE_STATIC:
+            case BASE_MAC_FORWARDING_TABLE_STATIC:
                 entry->is_static = cps_api_object_attr_data_u32(it.attr);
+                if(entry->is_static){
+                    entry->cache = true;
+                }
                 break;
 
             case BASE_MAC_TABLE_CONFIGURE_OS:
+            case BASE_MAC_FORWARDING_TABLE_CONFIGURE_OS:
                 entry->os_configured = cps_api_object_attr_data_u32(it.attr);
                 break;
 
             case BASE_MAC_TABLE_CONFIGURE_NPU:
+            case BASE_MAC_FORWARDING_TABLE_CONFIGURE_NPU:
+
                 entry->npu_configured = cps_api_object_attr_data_u32(it.attr);
+                break;
+
+            case BASE_MAC_FORWARDING_TABLE_BR_NAME:
+            {
+
+                const char * name = (const char *)cps_api_object_attr_data_bin(it.attr);
+                interface_ctrl_t i;
+                memset(&i,0,sizeof(i));
+                strncpy(i.if_name,name,sizeof(i.if_name)-1);
+                i.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+                if (dn_hal_get_interface_info(&i)!=STD_ERR_OK){
+                    EV_LOGGING(L2MAC, DEBUG, "NAS-MAC",
+                            "Can't get interface control information for %s",name);
+                        return STD_ERR(MAC,FAIL,0);
+                }
+
+                if(i.int_type == nas_int_type_DOT1D_BRIDGE){
+                    entry->bridge_ifindex = i.if_index;
+                    entry->bridge_id = i.bridge_id;
+                    attrs.add(BASE_MAC_FORWARDING_TABLE_BR_NAME);
+                }else{
+                    NAS_MAC_LOG(ERR,"Failed to find bridge %s information",name);
+                }
+            }
+                break;
+
+            case BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP_ADDR_FAMILY:
+                entry->endpoint_ip.af_index = cps_api_object_attr_data_u32(it.attr);
+                attrs.add(BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP_ADDR_FAMILY);
+                entry->entry_type = NDI_MAC_ENTRY_TYPE_1D_REMOTE;
+                break;
+
+            case BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP_ADDR:
+                {
+
+                cps_api_object_attr_t af_attr;
+                af_attr = cps_api_object_attr_get(obj, BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP_ADDR_FAMILY);
+                if(!af_attr){
+                    NAS_MAC_LOG(ERR,"Can't have IP address without Address Class");
+                    return false;
+                }
+                entry->endpoint_ip.af_index = cps_api_object_attr_data_u32(af_attr);
+                attrs.add(BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP_ADDR_FAMILY);
+
+                }
+
+                if(entry->endpoint_ip.af_index == AF_INET){
+                    memcpy(&entry->endpoint_ip.u.ipv4,cps_api_object_attr_data_bin(it.attr),
+                            sizeof(entry->endpoint_ip.u.ipv4));
+                }else{
+                    memcpy(&entry->endpoint_ip.u.ipv6,cps_api_object_attr_data_bin(it.attr),
+                                            sizeof(entry->endpoint_ip.u.ipv6));
+                }
+                attrs.add(BASE_MAC_FORWARDING_TABLE_ENDPOINT_IP);
+                break;
+
+            case BASE_MAC_TABLE_PUBLISH:
+            case BASE_MAC_FORWARDING_TABLE_PUBLISH:
+                if(cps_api_object_attr_data_uint(it.attr)){
+                    entry->publish=true;
+                }
                 break;
 
             default:
@@ -134,23 +337,20 @@ static t_std_error nas_mac_obj_to_entry (cps_api_object_t obj, nas_mac_entry_t *
         }
     }
 
-    if( op == cps_api_oper_CREATE){
-        /* validate the params if it is a create request. */
-        if ((!valid_param_set[1]) || (!valid_param_set[2]) || (!valid_param_set[3])) {
-            NAS_MAC_LOG(ERR, "All the valid parameters(vlan/ifindex/mac)are not passed");
-            return STD_ERR(MAC,CFG,0);
-        }
-        if (!valid_param_set[0]) {
-            /* Use FORWARD as default action if not specified */
-            entry->pkt_action = BASE_MAC_PACKET_ACTION_FORWARD;
-        }
-    } else if (op == cps_api_oper_SET) {
-        /* validate the params if it is a set request. */
-        if (!valid_param_set[1] || !valid_param_set[3]) {
-            NAS_MAC_LOG(ERR, "All the valid parameters(vlan/mac)are not passed");
-            return STD_ERR(MAC,CFG,0);
-        }
+    if(!nas_mac_validate_params(attrs,op)){
+        NAS_MAC_LOG(ERR,"Failed to validate mac request");
+        return STD_ERR(MAC,FAIL,0);
     }
+
+    /*  Log MAC entry  */
+
+    const char *oper_type = NULL;
+    auto _oper_it = _oper_type.find(op);
+    if (_oper_it != _oper_type.end()) {
+        oper_type = _oper_it->second;
+        EV_LOGGING(L2MAC, INFO, "NAS-MAC", " CPS MAC Request: operation:  %s", oper_type);
+    }
+    nas_mac_log_entry(entry);
     return STD_ERR_OK;
 }
 
@@ -180,8 +380,20 @@ t_std_error nas_mac_update_entry_in_os(nas_mac_entry_t *entry,
      return rc;
 }
 
+bool _get_endpoint_tunnel_id(vni_rem_ip_t & _rem_ip, ndi_obj_id_t & obj_id){
+    std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+    auto it = tunnel_endpoint_map.find(_rem_ip);
+    if(it == tunnel_endpoint_map.end()){
+        NAS_MAC_LOG(ERR,"failed to find tunnel port id for bridge %d",
+                _rem_ip.br_index);
+        return false;
+    }
+    obj_id = it->second;
+    return true;
+}
 
 static bool nas_mac_fill_ndi_entry(ndi_mac_entry_t & ndi_mac_entry,nas_mac_entry_t & entry ){
+
     if(entry.ifindex != 0){
         interface_ctrl_t intf_ctrl;
         memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
@@ -203,8 +415,32 @@ static bool nas_mac_fill_ndi_entry(ndi_mac_entry_t & ndi_mac_entry,nas_mac_entry
         ndi_mac_entry.port_info.npu_port = intf_ctrl.port_id;
     }
 
-    ndi_mac_entry.vlan_id = entry.entry_key.vlan_id;
     ndi_mac_entry.npu_id = 0;
+    ndi_mac_entry.vlan_id = entry.entry_key.vlan_id;
+    ndi_mac_entry.mac_entry_type = entry.entry_type;
+
+    EV_LOGGING(L2MAC,DEBUG,"NAS-MAC", "nas_mac_fill_ndi_entry ifx %llu vlan_id %d type %d ",
+                                                       entry.ifindex, ndi_mac_entry.vlan_id, ndi_mac_entry.mac_entry_type );
+    if(entry.entry_type != NDI_MAC_ENTRY_TYPE_1Q){
+        ndi_mac_entry.bridge_id = entry.bridge_id;
+        if(entry.entry_type == NDI_MAC_ENTRY_TYPE_1D_REMOTE){
+            memcpy(&ndi_mac_entry.endpoint_ip,&entry.endpoint_ip,sizeof(ndi_mac_entry.endpoint_ip));
+            vni_rem_ip_t _rem_ip = { entry.endpoint_ip,entry.bridge_ifindex };
+            if(!_get_endpoint_tunnel_id(_rem_ip,ndi_mac_entry.endpoint_ip_port)){
+                return false;
+            }
+        } else {
+            /* Handle setting vlanid for untagged 1d bridge ports, could be attached ones or direct untagged ones */
+            if (ndi_mac_entry.vlan_id == 0) {
+                if (!nas_mac_get_1d_br_untag_vid(entry.bridge_ifindex, ndi_mac_entry.vlan_id)) {
+                    EV_LOGGING(L2MAC,ERR,"NAS-MAC", "failed to get vlan_id for 1d bridge ifindex %d.",entry.bridge_ifindex);
+                }
+
+
+            }
+
+        }
+    }
 
     memcpy(ndi_mac_entry.mac_addr, entry.entry_key.mac_addr, sizeof(hal_mac_addr_t));
     ndi_mac_entry.is_static = entry.is_static;
@@ -256,36 +492,256 @@ static void nas_mac_send_event_notification(nas_mac_entry_t & entry,nas_l2_mac_o
 }
 
 
+static bool _check_if_flooding_mac(hal_mac_addr_t & mac_addr){
+
+    hal_mac_addr_t _zero_mac = {0};
+    if(memcmp(mac_addr,_zero_mac,sizeof(hal_mac_addr_t)) == 0){
+        return true;
+    }
+
+    return false;
+}
+
+/*
+ * Publish an event when a remote end point is being added/deleted
+ */
+static bool nas_mac_publish_remote_ip_event(nas_mac_entry_t & _mac_entry,vni_rem_ip_t & entry,
+                                            cps_api_operation_types_t op){
+    if(op == cps_api_oper_CREATE){
+        if (remote_ip_event_mask.find(entry) != remote_ip_event_mask.end()){
+            return true;
+        }
+        remote_ip_event_mask.insert(entry);
+    }else if(op ==cps_api_oper_DELETE) {
+        remote_ip_event_mask.erase(entry);
+    }
+
+    cps_api_object_t obj = cps_api_object_create();
+    if(obj == nullptr){
+        NAS_MAC_LOG(ERR,"Failed to allocate memory for object publish");
+        return false;
+    }
+
+    cps_api_key_t key;
+    cps_api_key_from_attr_with_qual(&key,BASE_MAC_TUNNEL_ENDPOINT_EVENT_OBJ,
+                                          cps_api_qualifier_OBSERVED);
+    cps_api_object_set_key(obj,&key);
+
+    cps_api_object_attr_add_u32(obj,BASE_MAC_TUNNEL_ENDPOINT_EVENT_FLOODING_ENABLE,
+            op == cps_api_oper_SET ? false :
+            _check_if_flooding_mac(_mac_entry.entry_key.mac_addr) ? true : false);
+
+    interface_ctrl_t intf_ctrl;
+    memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
+
+    intf_ctrl.q_type = HAL_INTF_INFO_FROM_IF;
+    intf_ctrl.if_index = _mac_entry.ifindex;
+
+    if(dn_hal_get_interface_info(&intf_ctrl) == STD_ERR_OK) {
+        cps_api_object_attr_add(obj,BASE_MAC_TUNNEL_ENDPOINT_EVENT_INTERFACE_NAME,(const void *)intf_ctrl.if_name,
+                strlen(intf_ctrl.if_name)+1);
+    }
+
+    cps_api_object_attr_add_u32(obj,BASE_MAC_TUNNEL_ENDPOINT_EVENT_IP_ADDR_FAMILY,_mac_entry.endpoint_ip.af_index);
+
+    if(_mac_entry.endpoint_ip.af_index == AF_INET){
+        cps_api_object_attr_add(obj,BASE_MAC_TUNNEL_ENDPOINT_EVENT_IP_ADDR,(const void *)&_mac_entry.endpoint_ip.u.ipv4,
+               sizeof(_mac_entry.endpoint_ip.u.ipv4));
+    }else{
+        cps_api_object_attr_add(obj,BASE_MAC_TUNNEL_ENDPOINT_EVENT_IP_ADDR,(const void *)&_mac_entry.endpoint_ip.u.ipv6,
+                       sizeof(_mac_entry.endpoint_ip.u.ipv6));
+    }
+
+    cps_api_object_set_type_operation(cps_api_object_key(obj),op);
+    if(nas_mac_event_publish(obj) != STD_ERR_OK ){
+        return false;
+    }
+
+    return true;
+}
+
+
+bool nas_mac_update_remote_macs_cache(nas_mac_entry_t & entry,bool add){
+
+    if(!entry.cache){
+        return true;
+    }
+    std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+    std::string mac_addr;
+    nas_mac_get_str_from_mac(entry.entry_key.mac_addr,mac_addr);
+    vni_rem_ip_t rem_ip = { entry.endpoint_ip,entry.bridge_ifindex};
+    auto it  = vxlan_remote_macs.find(rem_ip);
+    if(add){
+        if(it == vxlan_remote_macs.end()){
+            nas_mac_str_list l = {mac_addr};
+            vxlan_remote_macs[rem_ip] = l;
+        }else{
+            it->second.insert(mac_addr);
+        }
+    }else{
+        if(it != vxlan_remote_macs.end()){
+            it->second.erase(mac_addr);
+            if(it->second.size()==0){
+                vxlan_remote_macs.erase(rem_ip);
+                return nas_mac_publish_remote_ip_event(entry,rem_ip,cps_api_oper_DELETE);
+            }else{
+                if(_check_if_flooding_mac(entry.entry_key.mac_addr)){
+                    return nas_mac_publish_remote_ip_event(entry,rem_ip,cps_api_oper_SET);
+                }
+            }
+        }
+    }
+
+    return true;
+
+}
+
+static bool _process_mac_entry(nas_mac_entry_t & entry){
+
+    if(entry.os_configured){
+        if( (nas_mac_update_entry_in_os(&entry,cps_api_oper_CREATE)) != STD_ERR_OK){
+            return false;
+        }
+    }
+
+    if(entry.npu_configured == true){
+        if((nas_mac_create_entry_hw(&entry))!=STD_ERR_OK){
+                return false;
+        }
+        if(entry.publish){
+            nas_mac_send_event_notification(entry,NAS_MAC_ADD);
+        }
+    }
+
+    return true;
+}
+
+static bool _nas_mac_update_hw(nas_mac_entry_t & entry, cps_api_operation_types_t op){
+
+    if(op == cps_api_oper_DELETE){
+        /*
+         * Delete the MAC in npu
+         */
+        if(!_check_if_flooding_mac(entry.entry_key.mac_addr)){
+            if(nas_mac_delete_entries_from_hw(&entry,NDI_MAC_DEL_SINGLE_ENTRY) != STD_ERR_OK){
+            return false;
+            }
+        }
+        return nas_mac_update_remote_macs_cache(entry,false);
+    }else if (op == cps_api_oper_CREATE){
+
+        if(_process_mac_entry(entry)){
+            return nas_mac_update_remote_macs_cache(entry,true);
+        }
+
+    }else{
+        // To see what needs to be done for update
+    }
+
+    return false;
+}
+
+
+static bool nas_mac_handle_remote_entry(nas_mac_entry_t & entry, cps_api_operation_types_t op){
+    /*
+     * check if the remote ip is known if not then publish an event to nas-intf
+     * about new remote endpoit
+     */
+    std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+    vni_rem_ip_t rem_ip = { entry.endpoint_ip,entry.bridge_ifindex};
+    auto it = known_rem_ips.find(rem_ip);
+    if( it == known_rem_ips.end()){
+        if(op == cps_api_oper_CREATE){
+            nas_mac_publish_remote_ip_event(entry,rem_ip,cps_api_oper_CREATE);
+            auto mac_it = vxlan_pending_macs.find(rem_ip);
+            if(mac_it == vxlan_pending_macs.end()){
+                nas_mac_list mac_l;
+                mac_l.push_back(entry);
+                vxlan_pending_macs[rem_ip] = mac_l;
+            }else{
+                mac_it->second.push_back(entry);
+            }
+        }
+    }else {
+        return _nas_mac_update_hw(entry,op);
+    }
+
+    return true;
+
+}
+
+
+static bool nas_mac_process_fdb_event(nas_mac_entry_t & entry, nas::attr_set_t & attr,
+                                      cps_api_operation_types_t op){
+
+    interface_ctrl_t i;
+    memset(&i,0,sizeof(i));
+    i.if_index = entry.bridge_ifindex;
+    i.q_type = HAL_INTF_INFO_FROM_IF;
+
+    if (dn_hal_get_interface_info(&i)!=STD_ERR_OK){
+        return false;
+    }
+
+    if(i.int_type == nas_int_type_DOT1D_BRIDGE){
+        entry.bridge_id = i.bridge_id;
+    }
+    attr.add(BASE_MAC_FORWARDING_TABLE_BR_NAME);
+
+    if(!nas_mac_validate_params(attr,op)){
+        return false;
+    }
+
+    entry.entry_type = NDI_MAC_ENTRY_TYPE_1D_REMOTE;
+    return nas_mac_handle_remote_entry(entry,op);
+}
+
+
+bool nas_mac_process_os_event(nas_mac_entry_t & entry, nas::attr_set_t & attr, cps_api_operation_types_t op){
+
+
+    if(attr.contains(BASE_MAC_TABLE_IFINDEX)){
+        if(nas_mac_get_bridge_from_vtep(entry.ifindex,entry.bridge_ifindex)){
+            return nas_mac_process_fdb_event(entry,attr,op);
+        }else{
+            std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+            _remote_pending_entry _e = { entry,attr,op};
+            auto it = _remote_pending_entry_map.find(entry.ifindex);
+            if(it == _remote_pending_entry_map.end()){
+                _remote_entry_list _l;
+                _l.push_back(_e);
+                _remote_pending_entry_map[entry.ifindex] = _l;
+            }
+            _remote_pending_entry_map[entry.ifindex].push_back(_e);
+        }
+    }
+
+    return true;
+}
+
+
 t_std_error nas_mac_cps_create_entry (cps_api_object_t obj){
 
     t_std_error rc;
     nas_mac_entry_t entry;
+
 
     if ((rc = nas_mac_obj_to_entry(obj, &entry)) != STD_ERR_OK) {
         NAS_MAC_LOG(DEBUG, "Object to Entry conversion failed ");
         return rc;
     }
 
-    if(entry.os_configured==true){
-        if((rc = nas_mac_update_entry_in_os(&entry,cps_api_oper_CREATE)) != STD_ERR_OK){
-            return rc;
+    if(entry.entry_type == NDI_MAC_ENTRY_TYPE_1Q || entry.entry_type == NDI_MAC_ENTRY_TYPE_1D_LOCAL){
+        if(!_process_mac_entry(entry)){
+            return STD_ERR(MAC,FAIL,0);
+        }
+    }else{
+        if(!nas_mac_handle_remote_entry(entry,cps_api_oper_CREATE)){
+            return STD_ERR(MAC,FAIL,0);
         }
     }
 
-    if(entry.npu_configured == true){
-        if((rc = nas_mac_create_entry_hw(&entry))!=STD_ERR_OK){
-            return rc;
-        }
-        cps_api_object_attr_t _pub_attr = cps_api_object_attr_get(obj,BASE_MAC_TABLE_PUBLISH);
-        if(_pub_attr){
-            bool _publish = cps_api_object_attr_data_u32(_pub_attr);
-            if(_publish){
-                nas_mac_send_event_notification(entry,NAS_MAC_ADD);
-            }
-        }
 
-
-    }
 
     return STD_ERR_OK;
 }
@@ -311,6 +767,16 @@ static t_std_error nas_mac_update_entry(nas_mac_entry_t *entry){
         }
 
         if(entry->npu_configured){
+            /*
+             * For 1D remote entry to move the mac to tunnel bridge port
+             * SAI need two attributes one is new port and another one is
+             * the remote ip address. Currently SAI only allows one attribute
+             * to be updated at a time. So instead of calling update, need to
+             * call create mac entry.
+             */
+            if(ndi_mac_entry.mac_entry_type == NDI_MAC_ENTRY_TYPE_1D_REMOTE){
+                return ndi_create_mac_entry(&ndi_mac_entry);
+            }
             if((rc = ndi_update_mac_entry(&ndi_mac_entry,NDI_MAC_ENTRY_ATTR_PORT_ID)) != STD_ERR_OK){
                 return rc;
             }
@@ -331,7 +797,6 @@ t_std_error nas_mac_cps_update_entry (cps_api_object_t obj){
 
     t_std_error rc;
     nas_mac_entry_t entry;
-    memset(&entry, 0, sizeof(nas_mac_entry_t));
 
     if ((rc = nas_mac_obj_to_entry(obj, &entry)) != STD_ERR_OK) {
         NAS_MAC_LOG(DEBUG, "Object to Entry conversion failed ");
@@ -346,7 +811,7 @@ static bool is_filter_type_present (nas_mac_entry_t *entry, del_filter_type_t fi
     memset(&zero_mac, 0, sizeof(hal_mac_addr_t));
     switch (filter_type) {
         case DEL_VLAN_FILTER:
-            if (entry->entry_key.vlan_id != 0) {
+            if (entry->entry_key.vlan_id != 0 || entry->bridge_id != 0) {
                 return true;
             }
             break;
@@ -396,28 +861,19 @@ static void nas_mac_fill_flush_entry (nas_mac_cps_event_t & flush_entry) {
 
     flush_entry.op_type = NAS_MAC_DEL;
     flush_entry.del_type = del_type;
-    flush_entry.subtype_all = flush_entry.entry.is_static ? true : false;
-
     return;
 }
 
+/*  TODO now separate thread for flush handling has been removed.
+ *  Clean-up needs to be done. */
+t_std_error nas_mac_send_cps_event(nas_mac_cps_event_t * entries, int count){
 
-t_std_error nas_mac_send_cps_event(nas_mac_cps_event_t * entry, int count){
-    int cps_event_len = count * sizeof(nas_mac_cps_event_t);
-    int len = sizeof(nas_l2_event_header_t) + cps_event_len;
-    void * data = calloc(len,sizeof(char));
-    if(data){
-        nas_l2_event_header_t *hdr = (nas_l2_event_header_t *)data;
-        hdr->ev_type = NAS_MAC_CPS_EVENT;
-        hdr->len = count;
-        nas_mac_cps_event_t * mac_event = (nas_mac_cps_event_t *)((char *)data + sizeof(nas_l2_event_header_t));
-        memcpy((void  *)mac_event,(void *)entry,cps_event_len);
-        nas_mac_send_cps_event_notification(data,len);
-        free(data);
-        return STD_ERR_OK;
+
+    for (int i =0; i < count; i ++) {
+
+        nas_mac_clear_hw_mac(entries[i]);
     }
-
-    return STD_ERR(MAC,FAIL,0);
+    return STD_ERR_OK;
 }
 
 
@@ -429,8 +885,17 @@ t_std_error nas_mac_cps_delete_entry (cps_api_object_t obj){
         NAS_MAC_LOG(ERR, "Object to Entry conversion failed ");
         return rc;
     }
-    nas_mac_fill_flush_entry(flush_entry);
-    return nas_mac_send_cps_event(&flush_entry,1);
+
+    if(flush_entry.entry.entry_type == NDI_MAC_ENTRY_TYPE_1Q ||
+        flush_entry.entry.entry_type == NDI_MAC_ENTRY_TYPE_1D_LOCAL){
+        nas_mac_fill_flush_entry(flush_entry);
+        return nas_mac_send_cps_event(&flush_entry,1);
+    }else{
+        if(!nas_mac_handle_remote_entry(flush_entry.entry,cps_api_oper_DELETE)){
+            return STD_ERR(MAC,FAIL,0);
+        }
+    }
+    return STD_ERR_OK;
 
 }
 
@@ -438,11 +903,239 @@ t_std_error nas_mac_cps_delete_entry (cps_api_object_t obj){
 t_std_error nas_mac_flush_vlan_entries_of_port(uint32_t vlan, hal_ifindex_t port_index) {
 
     nas_mac_cps_event_t flush_entry;
-    memset(&flush_entry.entry, 0, sizeof(nas_mac_entry_t));
     flush_entry.entry.ifindex = port_index;
     flush_entry.entry.entry_key.vlan_id = vlan;
     nas_mac_fill_flush_entry(flush_entry);
     return nas_mac_send_cps_event(&flush_entry,1);
+}
+
+static bool _get_ifindex_from_name(const char *name,hal_ifindex_t & index){
+    interface_ctrl_t i;
+    memset(&i,0,sizeof(interface_ctrl_t));
+    strncpy(i.if_name,name,sizeof(i.if_name)-1);
+    i.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+    if (dn_hal_get_interface_info(&i)!=STD_ERR_OK){
+        return false;
+    }
+    index = i.if_index;
+    return true;
+}
+
+static bool _port_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                cps_api_attr_id_t * ids,size_t ids_len){
+    ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_IFINDEX;
+    cps_api_object_attr_t ifindex_attr = cps_api_object_e_get(obj,ids,sizeof(ids[0]));
+    ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_IFNAME;
+    cps_api_object_attr_t ifname_attr = cps_api_object_e_get(obj,ids,ids_len);
+    entry.entry_type = NDI_MAC_ENTRY_TYPE_1Q;
+    if(ifindex_attr){
+        entry.ifindex = cps_api_object_attr_data_u32(ifindex_attr);
+        return true;
+    }
+
+    if(ifname_attr){
+        const char * name = (const char *)cps_api_object_attr_data_bin(ifname_attr);
+        return _get_ifindex_from_name(name,entry.ifindex);
+    }
+    return false;
+}
+
+static bool _vlan_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                cps_api_attr_id_t * ids,size_t ids_len){
+     ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_VLAN;
+     entry.entry_type = NDI_MAC_ENTRY_TYPE_1Q;
+     cps_api_object_attr_t vlan_attr = cps_api_object_e_get(obj,ids,ids_len);
+     if(vlan_attr){
+         entry.entry_key.vlan_id = cps_api_object_attr_data_uint(vlan_attr);
+         return true;
+     }
+    return false;
+}
+
+static bool _subport_bridge_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                cps_api_attr_id_t * ids,size_t ids_len) {
+    /* Check for bridge name . For untagged .1d or attached vlan brports vlan id sent is 0 */
+    ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_BR_NAME;
+    cps_api_object_attr_t br_attr = cps_api_object_e_get(obj,ids,ids_len);
+    if (br_attr) {
+        const char *name = (const char *) cps_api_object_attr_data_bin(br_attr);
+        interface_ctrl_t i;
+        memset(&i,0,sizeof(i));
+        safestrncpy(i.if_name,name,sizeof(i.if_name));
+        i.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+        if (dn_hal_get_interface_info(&i)!=STD_ERR_OK){
+            EV_LOGGING(L2MAC, DEBUG, "NAS-MAC",
+              "Can't get interface control information for %s",name);
+            return false;
+        }
+        /* Find VLAN id for this bridge */
+        nas_mac_get_1d_br_untag_vid(i.if_index, entry.entry_key.vlan_id);
+        EV_LOGGING(L2MAC, DEBUG, "NAS-MAC", "Untagged subport flush :bridge ifindex %d ,untagged vlan id %d \n",
+                 i.if_index, entry.entry_key.vlan_id);
+        return true;
+     } else {
+         NAS_MAC_LOG(ERR, " Untagged Subport flush : with no bridge name");
+         return false;
+     }
+
+}
+
+static bool _port_vlan_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                    cps_api_attr_id_t *ids,size_t ids_len){
+
+    return (_port_flush_handler(entry,obj,ids,ids_len) && _vlan_flush_handler(entry,obj,ids,ids_len));
+}
+
+static bool _port_bridge_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                      cps_api_attr_id_t *ids,size_t ids_len) {
+
+    return (_port_flush_handler(entry,obj,ids,ids_len) && _subport_bridge_handler(entry,obj,ids,ids_len));
+
+
+}
+
+static bool _port_vlan_subport_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                    cps_api_attr_id_t *ids,size_t ids_len){
+
+    if ( (_port_flush_handler(entry,obj,ids,ids_len) && _vlan_flush_handler(entry,obj,ids,ids_len)) ) {
+        entry.entry_type = NDI_MAC_ENTRY_TYPE_1D_LOCAL;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+
+static bool _bridge_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                    cps_api_attr_id_t * ids,size_t ids_len){
+    ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_BR_NAME;
+    cps_api_object_attr_t br_attr = cps_api_object_e_get(obj,ids,ids_len);
+    entry.entry_type = NDI_MAC_ENTRY_TYPE_1D_LOCAL;
+    if(br_attr){
+        const char *name = (const char *) cps_api_object_attr_data_bin(br_attr);
+        interface_ctrl_t i;
+        memset(&i,0,sizeof(i));
+        strncpy(i.if_name,name,sizeof(i.if_name)-1);
+        i.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+        if (dn_hal_get_interface_info(&i)!=STD_ERR_OK){
+           EV_LOGGING(L2MAC, DEBUG, "NAS-MAC",
+                   "Can't get interface control information for %s",name);
+           return false;
+        }
+
+        if(i.int_type == nas_int_type_DOT1D_BRIDGE){
+           entry.bridge_ifindex = i.if_index;
+           entry.bridge_id = i.bridge_id;
+           return true;
+        }else{
+           NAS_MAC_LOG(ERR,"Failed to find Dot1d bridge %s information",name);
+           return false;
+        }
+    }
+    return false;
+}
+
+
+static bool _bridge_endpoint_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                            cps_api_attr_id_t *ids,size_t ids_len){
+    ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_ENDPOINT_IP;
+    cps_api_object_attr_t ip_attr = cps_api_object_e_get(obj,ids,ids_len);
+    if((_bridge_flush_handler(entry,obj,ids,ids_len)) && ip_attr){
+        memcpy(&entry.endpoint_ip,(void *)cps_api_object_attr_data_bin(ip_attr),
+                                    sizeof(entry.endpoint_ip));
+        char ip_addr_str[HAL_INET6_TEXT_LEN];
+        if(std_ip_to_string(&entry.endpoint_ip,ip_addr_str,HAL_INET6_LEN) == NULL){
+            NAS_MAC_LOG(ERR,"Invalid IP Address in Endpoint Event notification");
+            return false;
+        }
+        entry.entry_type = NDI_MAC_ENTRY_TYPE_1D_REMOTE;
+
+
+        return true;
+    }
+    return false;
+}
+
+
+static bool _all_flush_handler(nas_mac_entry_t & entry, cps_api_object_t obj,
+                                cps_api_attr_id_t * ids,size_t ids_len){
+    return true;
+}
+
+
+static auto _flush_fn_map = * new std::unordered_map<BASE_MAC_MAC_FLUSH_TYPE_t, bool (*)
+                (nas_mac_entry_t & _entry,cps_api_object_t obj,cps_api_attr_id_t *ids,
+                size_t ids_len ),std::hash<int>>
+{
+    {BASE_MAC_MAC_FLUSH_TYPE_PORT,_port_flush_handler},
+    {BASE_MAC_MAC_FLUSH_TYPE_VLAN,_vlan_flush_handler},
+    {BASE_MAC_MAC_FLUSH_TYPE_VLAN_PORT,_port_vlan_flush_handler},
+    {BASE_MAC_MAC_FLUSH_TYPE_BRIDGE,_bridge_flush_handler},
+    {BASE_MAC_MAC_FLUSH_TYPE_BRIDGE_ENDPOINT_IP,_bridge_endpoint_flush_handler},
+    {BASE_MAC_MAC_FLUSH_TYPE_ALL,_all_flush_handler},
+    {BASE_MAC_MAC_FLUSH_TYPE_VLAN_PORT_SUBPORT,_port_vlan_subport_flush_handler}, /*  for tagged 1d bridge member  */
+    {BASE_MAC_MAC_FLUSH_TYPE_BRIDGE_PORT, _port_bridge_flush_handler}, /* for untagged subport */
+
+
+};
+
+static auto _nas_to_ndi_flush_type =  * new std::unordered_map<BASE_MAC_MAC_FLUSH_TYPE_t,
+                                                                ndi_mac_delete_type_t,std::hash<int>>{
+    {BASE_MAC_MAC_FLUSH_TYPE_PORT,NDI_MAC_DEL_BY_PORT},
+    {BASE_MAC_MAC_FLUSH_TYPE_VLAN,NDI_MAC_DEL_BY_VLAN},
+    {BASE_MAC_MAC_FLUSH_TYPE_VLAN_PORT,NDI_MAC_DEL_BY_PORT_VLAN},
+    {BASE_MAC_MAC_FLUSH_TYPE_BRIDGE,NDI_MAC_DEL_BY_BRIDGE},
+    {BASE_MAC_MAC_FLUSH_TYPE_BRIDGE_ENDPOINT_IP,NDI_MAC_DEL_BY_BRIDGE_ENDPOINT_IP},
+    {BASE_MAC_MAC_FLUSH_TYPE_VLAN_PORT_SUBPORT,NDI_MAC_DEL_BY_PORT_VLAN_SUBPORT},
+    {BASE_MAC_MAC_FLUSH_TYPE_ALL,NDI_MAC_DEL_ALL_ENTRIES},
+    {BASE_MAC_MAC_FLUSH_TYPE_BRIDGE_PORT ,NDI_MAC_DEL_BY_PORT_VLAN_SUBPORT},
+};
+
+
+static bool nas_mac_flush_remote_ip(std::vector<nas_mac_cps_event_t> & flush_queue, cps_api_object_t obj,
+                                cps_api_attr_id_t * ids, size_t ids_len){
+    ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_ENDPOINT_IP_ADDR;
+    cps_api_object_attr_t ip_attr = cps_api_object_e_get(obj,ids,ids_len);
+    ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_ENDPOINT_IP_ADDR_FAMILY;
+    cps_api_object_attr_t af_attr = cps_api_object_e_get(obj,ids,ids_len);
+    hal_ip_addr_t ip_addr;
+    if(!ip_attr || !af_attr){
+        return false;
+    }
+
+    ip_addr.af_index = cps_api_object_attr_data_u32(af_attr);
+
+    if(ip_addr.af_index == AF_INET){
+        memcpy(&ip_addr.u.ipv4,cps_api_object_attr_data_bin(ip_attr),
+                sizeof(ip_addr.u.ipv4));
+    }else{
+        memcpy(&ip_addr.u.ipv6,cps_api_object_attr_data_bin(ip_attr),
+                sizeof(ip_addr.u.ipv6));
+    }
+
+    char ip_addr_str[HAL_INET6_TEXT_LEN];
+    if(std_ip_to_string(&ip_addr,ip_addr_str,HAL_INET6_LEN) == NULL){
+        NAS_MAC_LOG(ERR,"Invalid IP Address in Endpoint IP flush");
+        return false;
+    }
+
+    nas_mac_cps_event_t flush_entry;
+    flush_entry.op_type = NAS_MAC_DEL;
+    flush_entry.del_type = NDI_MAC_DEL_BY_BRIDGE_ENDPOINT_IP;
+    flush_entry.entry.entry_type = NDI_MAC_ENTRY_TYPE_1D_REMOTE;
+    memcpy(&flush_entry.entry.endpoint_ip,&ip_addr,sizeof(hal_ip_addr_t));
+    std::string ip_str(ip_addr_str);
+
+    std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+    for(auto it : tunnel_endpoint_map){
+        if(it.first.ip == ip_str){
+            flush_entry.entry.bridge_ifindex = it.first.br_index;
+            flush_queue.push_back(flush_entry);
+            EV_LOGGING(L2MAC,INFO,"FLUSH","Flushing for IP %s and bridge %d",ip_addr_str,it.first.br_index);
+        }
+    }
+
+    return true;
 }
 
 
@@ -457,43 +1150,32 @@ static bool nas_mac_flush_entries(cps_api_object_t obj,const cps_api_object_it_t
     for (cps_api_object_it_inside (&it_lvl_1); cps_api_object_it_valid (&it_lvl_1);
          cps_api_object_it_next (&it_lvl_1)) {
 
-        memset(&flush_entry,0,sizeof(nas_mac_cps_event_t));
         ids[1] = cps_api_object_attr_id (it_lvl_1.attr);
-        ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_VLAN;
-        cps_api_object_attr_t vlan_attr = cps_api_object_e_get(obj,ids,ids_len);
-        ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_IFINDEX;
-        cps_api_object_attr_t ifindex_attr = cps_api_object_e_get(obj,ids,ids_len);
-        ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_IFNAME;
-        cps_api_object_attr_t ifname_attr = cps_api_object_e_get(obj,ids,ids_len);
+        ids[2]=BASE_MAC_FLUSH_INPUT_FILTER_FLUSH_TYPE;
+        cps_api_object_attr_t type_attr = cps_api_object_e_get(obj,ids,ids_len);
 
-        if(vlan_attr == NULL && ifindex_attr == NULL){
+        if(!type_attr){
             continue;
         }
 
-        if(vlan_attr){
-            flush_entry.entry.entry_key.vlan_id = cps_api_object_attr_data_u16(vlan_attr);
-        }
+        BASE_MAC_MAC_FLUSH_TYPE_t _flush_type = (BASE_MAC_MAC_FLUSH_TYPE_t)
+                                                 cps_api_object_attr_data_uint(type_attr);
 
-        if(ifindex_attr){
-            flush_entry.entry.ifindex = cps_api_object_attr_data_u32(ifindex_attr);
-        }
+        if(_flush_type == BASE_MAC_MAC_FLUSH_TYPE_ENDPOINT_IP){
+            nas_mac_flush_remote_ip(flush_queue,obj,ids,ids_len);
+        }else{
+            auto it = _flush_fn_map.find(_flush_type);
+            if(it == _flush_fn_map.end()){
+                NAS_MAC_LOG(ERR,"Invalid flush type passed %d",_flush_type);
+                continue;
+            }
 
-        if(ifname_attr){
-             const char * name = (const char *)cps_api_object_attr_data_bin(ifname_attr);
-             interface_ctrl_t i;
-             memset(&i,0,sizeof(interface_ctrl_t));
-             strncpy(i.if_name,name,sizeof(i.if_name)-1);
-             i.q_type = HAL_INTF_INFO_FROM_IF_NAME;
-             if (dn_hal_get_interface_info(&i)!=STD_ERR_OK){
-                 EV_LOGGING(L2MAC, DEBUG, "NAS-MAC",
-                     "Can't get interface control information for %s",name);
-                      return false;
-             }
-             flush_entry.entry.ifindex = i.if_index;
+            if(_flush_fn_map[_flush_type](flush_entry.entry,obj,ids,ids_len)){
+                flush_entry.op_type = NAS_MAC_DEL;
+                flush_entry.del_type = _nas_to_ndi_flush_type[_flush_type];
+                flush_queue.push_back(flush_entry);
+            }
         }
-
-        nas_mac_fill_flush_entry(flush_entry);
-        flush_queue.push_back(flush_entry);
     }
 
     return nas_mac_send_cps_event(&flush_queue[0],flush_queue.size()) == STD_ERR_OK ? true : false;
@@ -529,7 +1211,6 @@ t_std_error nas_mac_cps_flush_entry(cps_api_object_t obj){
 t_std_error nas_mac_handle_if_down(hal_ifindex_t ifindex){
 
     nas_mac_cps_event_t flush_entry;
-    memset(&flush_entry.entry, 0, sizeof(nas_mac_entry_t));
     flush_entry.entry.ifindex = ifindex;
     nas_mac_fill_flush_entry(flush_entry);
     return nas_mac_send_cps_event(&flush_entry,1);
@@ -548,33 +1229,41 @@ void nas_mac_event_notification_cb(npu_id_t npu_id, ndi_mac_event_type_t ev_type
     if(ev_type == NDI_MAC_EVENT_INVALID) return;
 
     nas_mac_npu_event_t  mac_event;
-    memset(&mac_event,0,sizeof(mac_event));
     interface_ctrl_t intf_ctrl;
     hal_ifindex_t lag_index;
+    mac_event.entry.entry_type = mac_entry->mac_entry_type;
 
-    if (!is_lag_index) {
-        memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
+    if(mac_event.entry.entry_type == NDI_MAC_ENTRY_TYPE_1D_REMOTE){
+           memcpy(&mac_event.entry.endpoint_ip,&mac_entry->endpoint_ip,sizeof(mac_event.entry.endpoint_ip));
+           mac_event.entry.endpoint_ip_id = mac_entry->endpoint_ip_port;
+    }else{
+        if (!is_lag_index) {
+            memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
 
-        intf_ctrl.q_type = HAL_INTF_INFO_FROM_PORT;
-        intf_ctrl.npu_id = mac_entry->port_info.npu_id;
-        intf_ctrl.port_id = mac_entry->port_info.npu_port;
+            intf_ctrl.q_type = HAL_INTF_INFO_FROM_PORT;
+            intf_ctrl.npu_id = mac_entry->port_info.npu_id;
+            intf_ctrl.port_id = mac_entry->port_info.npu_port;
 
-        if (dn_hal_get_interface_info(&intf_ctrl) != STD_ERR_OK) {
-            NAS_MAC_LOG(ERR, "NDI MAC Get interface failed.");
-            return;
+            if (dn_hal_get_interface_info(&intf_ctrl) != STD_ERR_OK) {
+                NAS_MAC_LOG(ERR, "NDI MAC Get interface failed.");
+                return;
+            }
+            mac_event.entry.ifindex = intf_ctrl.if_index;
+        } else {
+            if (nas_get_lag_if_index(mac_entry->ndi_lag_id,&lag_index) != STD_ERR_OK) {
+                NAS_MAC_LOG(ERR,"Failed to get Lag ifindex for ndi lag id 0x%x",mac_entry->ndi_lag_id);
+                return;
+            }
+            mac_event.entry.ifindex = lag_index;
         }
-        mac_event.entry.ifindex = intf_ctrl.if_index;
-    } else {
-        if (nas_get_lag_if_index(mac_entry->ndi_lag_id,&lag_index) != STD_ERR_OK) {
-            NAS_MAC_LOG(ERR,"Failed to get Lag ifindex for ndi lag id 0x%lx",mac_entry->ndi_lag_id);
-            return;
-        }
-        mac_event.entry.ifindex = lag_index;
     }
 
     mac_event.entry.entry_key.vlan_id = mac_entry->vlan_id;
     memcpy(mac_event.entry.entry_key.mac_addr, mac_entry->mac_addr, sizeof(hal_mac_addr_t));
     mac_event.entry.pkt_action = mac_entry->action;
+    mac_event.entry.bridge_id = mac_entry->bridge_id;
+
+
 
     auto it = ndi_to_nas_mac_ev->find(ev_type);
     if(it != ndi_to_nas_mac_ev->end()){
@@ -630,3 +1319,132 @@ bool nas_get_mac_entry_from_ndi(nas_mac_entry_t & entry){
     return true;
 }
 
+
+static bool _process_pending_macs(vni_rem_ip_t & _rem_ip){
+    auto it = vxlan_pending_macs.find(_rem_ip);
+    if (it == vxlan_pending_macs.end()){
+        NAS_MAC_LOG(ERR,"Failed to find pending mac for bridge %d",_rem_ip.br_index);
+        return false;
+    }
+
+    for (auto macs : it->second){
+        /*
+         * flooding macs doesn't need to be pushed to npu
+         */
+        if(_check_if_flooding_mac(macs.entry_key.mac_addr)){
+            nas_mac_update_remote_macs_cache(macs,true);
+            continue;
+        }
+
+        if(nas_mac_create_entry_hw(&macs) == STD_ERR_OK){
+            nas_mac_update_remote_macs_cache(macs,true);
+        }
+    }
+
+    vxlan_pending_macs.erase(it);
+
+    return true;
+}
+
+bool _process_remote_endpint(const char *  vtep_name, hal_ip_addr_t & ip_addr, ndi_obj_id_t tunnel_id,bool add){
+
+    if(!tunnel_id){
+        return false;
+    }
+
+    interface_ctrl_t intf_ctrl;
+    memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
+    intf_ctrl.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+    strncpy(intf_ctrl.if_name,vtep_name,sizeof(intf_ctrl.if_name)-1);
+
+    if (dn_hal_get_interface_info(&intf_ctrl) != STD_ERR_OK) {
+        NAS_MAC_LOG(ERR, "NDI MAC Get interface failed.");
+        return false;
+    }
+
+    if(intf_ctrl.int_type != nas_int_type_VXLAN){
+        return true;
+    }
+
+    hal_ifindex_t bridge_index=0;
+    if(!nas_mac_get_bridge_from_vtep(intf_ctrl.if_index,bridge_index)){
+        NAS_MAC_LOG(ERR,"Failed to find bridge for vtep %d",intf_ctrl.if_index);
+        return false;
+    }
+
+    vni_rem_ip_t _rem_ip = {ip_addr,bridge_index};
+
+    std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+
+    if(add){
+        known_rem_ips.insert(_rem_ip);
+        tunnel_endpoint_map[_rem_ip]=tunnel_id;
+        tunnel_id_to_vtep_map[tunnel_id]=vtep_name;
+        _process_pending_macs(_rem_ip);
+    }else{
+        known_rem_ips.erase(_rem_ip);
+        tunnel_id_to_vtep_map.erase(tunnel_id);
+        tunnel_endpoint_map.erase(_rem_ip);
+    }
+
+
+    return true;
+}
+
+static bool _process_pending_vtep_mac(hal_ifindex_t vtep_index, hal_ifindex_t br_index){
+    std::lock_guard<std::recursive_mutex> _lk(_vxlan_mtx);
+    auto it = _remote_pending_entry_map.find(vtep_index);
+    if(it == _remote_pending_entry_map.end()){
+        return true;
+    }
+    for(auto _e : it->second){
+        _e.entry.bridge_ifindex = br_index;
+        nas_mac_process_fdb_event(_e.entry,_e.attrs,_e.op);
+    }
+    _remote_pending_entry_map.erase(it);
+    return true;
+}
+
+/*  Handle vtep member addition to a 1D bridge. Add all pending MAC address configured
+ *  on the vxlan interface in the NPU
+ *  */
+bool _process_bridge_event(const char * br_name, const char * vtep_name, bool add){
+    interface_ctrl_t intf_ctrl;
+    memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
+
+    intf_ctrl.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+    strncpy(intf_ctrl.if_name,vtep_name,sizeof(intf_ctrl.if_name)-1);
+    if (dn_hal_get_interface_info(&intf_ctrl) != STD_ERR_OK) {
+        NAS_MAC_LOG(ERR, "NDI MAC Get interface failed.");
+        return false;
+    }
+
+    /*  IF not VTEP member then ignore the event  */
+    if(intf_ctrl.int_type != nas_int_type_VXLAN){
+        return true;
+    }
+    hal_ifindex_t vtep_index = intf_ctrl.if_index;
+
+    memset(&intf_ctrl, 0, sizeof(interface_ctrl_t));
+
+    NAS_MAC_LOG(INFO, " Handle VTEP member %s addition to the bridge %s", vtep_name, br_name);
+
+    intf_ctrl.q_type = HAL_INTF_INFO_FROM_IF_NAME;
+    strncpy(intf_ctrl.if_name,br_name,sizeof(intf_ctrl.if_name)-1);
+    if (dn_hal_get_interface_info(&intf_ctrl) != STD_ERR_OK) {
+        NAS_MAC_LOG(ERR, "NDI MAC Get interface failed for bridge %s.", br_name);
+        return false;
+    }
+    hal_ifindex_t br_index = intf_ctrl.if_index;
+
+    std::lock_guard<std::mutex> _lk(_bridge_mtx);
+    if(add){
+        vxlan_bridge_map[vtep_index]=br_index;
+        _process_pending_vtep_mac(vtep_index,br_index);
+    }else{
+        vxlan_bridge_map.erase(vtep_index);
+    }
+
+    return true;
+
+}

--- a/src/unit_test/mac_test.py
+++ b/src/unit_test/mac_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+# LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+# FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+
+
+import subprocess
+import time
+import sys
+import pytest
+
+
+class MacUnitTest:
+
+    def _run_cmds(self,in_cmd,ignore_err=False):
+        proc = subprocess.Popen(in_cmd.split(),stdout=subprocess.PIPE)
+        out,err = proc.communicate()
+        if not ignore_err:
+            if out.split()[-1] != "Success":
+                return False
+        return True
+
+    def _setup_ut(self):
+        _init_cmds = ["ip link add  link e101-001-0 name e101-001-0.100 type vlan id 100",
+                      "brctl addbr br100",
+                      "ip link add vtep100 type vxlan id 100 local 10.1.1.2 dstport 4789",
+                      "brctl addif br100 vtep100",
+                      "brctl addif br100 e101-001-0.100"]
+        for i in _init_cmds:
+            self._run_cmds(i,True)
+        time.sleep(0.5)
+        self._run_cmds("bridge fdb add 00:00:00:00:00:00 dev vtep100 dst 10.1.1.1",True)
+
+    def _cleanup_ut(self):
+        _cleanup_cmds = ["bridge fdb del 00:00:00:00:00:00 dev vtep100",
+                         "brctl delif br100 vtep100",
+                         "brctl delif br100 e101-001-0.100",
+                         "brctl delbr br100",
+                         "ip link del e101-001-0.100",
+                         "ip link del vtep100"
+                         ]
+        for i in _cleanup_cmds:
+            self._run_cmds(i,True)
+
+    def __init__(self):
+        self._setup_ut()
+        self.script_path = "/usr/bin/cps_config_mac.py "
+        self.test_ids = ["Create 1D Access","Delete 1D Access",
+                         "Create 1D Remote","Delete 1D Remote","Flush Peer IP","Flush PV Subport"]
+        self.test_cases = { "Create 1D Access" : "-o create -m 00:00:00:01:02:03 "
+                        "-i e101-001-0 -v 100 -b br100 -t 1D-Local" ,
+                        "Delete 1D Access" : "-o delete -m 00:00:00:01:02:03 "
+                        "-i e101-001-0 -v 100 -b br100 -t 1D-Local --del-type single",
+                        "Create 1D Remote": "-o create -m 00:00:00:01:02:04 -i vtep100 "
+                         "-b br100 --ip 10.1.1.2 --af ipv4 -t 1D-Remote",
+                         "Delete 1D Remote": "-o delete -m 00:00:00:01:02:04 -i vtep100 "
+                         "-b br100 --ip 10.1.1.2 --af ipv4 -t 1D-Remote --del-type single",
+                         "Flush Peer IP":"-o delete --ip 10.1.1.1 --af ipv4 --del-type endpoint-ip",
+                        "Flush PV Subport":"-o delete -i e101-001-0 -v 100 --del-type port-vlan-subport"}
+
+    def _run_test_case(self):
+        tc_passed = 0
+        tc_failed = 0
+        for tc in self.test_ids:
+            print "===================================================================="
+            print "Running Test Case " + tc
+            if self._run_cmds(self.script_path + self.test_cases[tc]):
+                print "Passed Test Case " + tc
+                tc_passed = tc_passed + 1
+            else:
+                print "Failed Test Case " + tc
+                tc_failed = tc_failed + 1
+
+        print "===================================================================="
+        print "Passed Test Cases ", tc_passed
+        print "Failed Test Cases ", tc_failed
+        self._cleanup_ut()
+        if tc_failed:
+            return False
+        return True
+
+
+
+def test_mac_1d_config():
+    test = MacUnitTest()
+    assert test._run_test_case() == True

--- a/src/unit_test/nas_mcast_unittest.cpp
+++ b/src/unit_test/nas_mcast_unittest.cpp
@@ -614,15 +614,13 @@ static bool send_mc_update_event(hal_vlan_id_t vlan_id, const string& if_name,
         ret_val = true;
     } while(0);
 
-    sleep(1);
-
     if (event_start_internal) {
         event_service_deinit();
     }
 
     return ret_val;
 }
-
+#if 0
 static bool is_ipv4_addr(const string& ip_addr)
 {
     struct in_addr addr;
@@ -634,6 +632,7 @@ static bool is_ipv6_addr(const string& ip_addr)
     struct in6_addr addr;
     return inet_pton(AF_INET6, ip_addr.c_str(), &addr);
 }
+#endif
 
 struct igmp_mld_entry
 {
@@ -653,7 +652,7 @@ enum class line_mark_t
 
 using line_check_func_t = function<line_mark_t(string)>;
 using handler_func_t = function<bool(const vector<string>&, vector<igmp_mld_entry>&)>;
-
+#if 0
 static line_mark_t igmp_entry_check(const string& line)
 {
     istringstream iss(line);
@@ -706,7 +705,6 @@ static void right_trim(string& in_str)
     string t{" \t\n\r"};
     in_str.erase(in_str.find_last_not_of(t) + 1);
 }
-
 static bool mld_entry_proc(const vector<string>& line_list, vector<igmp_mld_entry>& entry_list)
 {
     const string src_ip_tag = "SRC IP ADDRESS: ";
@@ -750,7 +748,6 @@ static bool mld_entry_proc(const vector<string>& line_list, vector<igmp_mld_entr
 
     return true;
 }
-
 static line_mark_t mc_group_check(const string& line)
 {
     const string start_tag = "Group ";
@@ -796,9 +793,11 @@ static bool mc_group_proc(const vector<string>& line_list, vector<igmp_mld_entry
 
     return true;
 }
+#endif
 
 static vector<igmp_mld_entry> mc_entry_list;
 
+#if 0
 static bool run_command(const string& cmd, line_check_func_t check_func, handler_func_t proc_func)
 {
     FILE *fp = popen(cmd.c_str(), "r");
@@ -854,7 +853,6 @@ static bool run_command(const string& cmd, line_check_func_t check_func, handler
     pclose(fp);
     return true;
 }
-
 static void dump_mc_entry_list()
 {
     char ip_buf[512];
@@ -872,7 +870,6 @@ static void dump_mc_entry_list()
         cout << "-----------------------------------" << endl;
     }
 }
-
 static void cleanup_intf_l2mc_config(hal_vlan_id_t vlan_id, const string& if_name)
 {
     cps_api_transaction_params_t params;
@@ -896,6 +893,7 @@ static void cleanup_intf_l2mc_config(hal_vlan_id_t vlan_id, const string& if_nam
     obj_g.release();
     ASSERT_TRUE(cps_api_commit(&params) == cps_api_ret_code_OK);
 }
+#endif
 
 // match: igmp, action: trap_to_cpu
 TEST(nas_mc, acl_rule_check)
@@ -993,8 +991,10 @@ TEST(nas_mc, send_ipv6_route_add_event)
     ASSERT_TRUE(send_mc_update_event(TEST_VID, ROUTE_LAG_IF_NAME, TEST_GRP_IPV6_LIST,TEST_SRC_IPV6_LIST, false, false, true));
 }
 
+#if 0
 TEST(nas_mc, validate_igmp_entry)
 {
+    sleep(1);
     mc_entry_list.clear();
     ASSERT_TRUE(run_command("hshell -c \"ipmc table show\"", igmp_entry_check, igmp_entry_proc));
     ASSERT_TRUE(mc_entry_list.size() > 0);
@@ -1016,6 +1016,7 @@ TEST(nas_mc, validate_mld_entry)
         ASSERT_TRUE(!entry.port_list.empty());
     }
 }
+#endif
 
 TEST(nas_mc, send_ipv4_route_del_event)
 {
@@ -1066,9 +1067,10 @@ TEST(nas_mc, send_ipv6_non_oif_route_add_event)
 }
 
 // All entries created should not link to group with member ports
-
+#if 0
 TEST(nas_mc, validate_igmp_non_oif_entry)
 {
+    sleep(1);
     mc_entry_list.clear();
     ASSERT_TRUE(run_command("hshell -c \"ipmc table show\"", igmp_entry_check, igmp_entry_proc));
     ASSERT_TRUE(mc_entry_list.size() > 0);
@@ -1090,6 +1092,7 @@ TEST(nas_mc, validate_mld_non_oif_entry)
         ASSERT_TRUE(entry.port_list.empty());
     }
 }
+#endif
 
 // Add mrouter port to make non-OIF entry not use default group
 
@@ -1100,9 +1103,10 @@ TEST(nas_mc, send_mrouter_add_event_1)
 }
 
 // Non-OIF entries should link to group with mrouter port members
-
+#if 0
 TEST(nas_mc, validate_igmp_entry_1)
 {
+    sleep(1);
     mc_entry_list.clear();
     ASSERT_TRUE(run_command("hshell -c \"ipmc table show\"", igmp_entry_check, igmp_entry_proc));
     ASSERT_TRUE(mc_entry_list.size() > 0);
@@ -1124,6 +1128,7 @@ TEST(nas_mc, validate_mld_entry_1)
         ASSERT_TRUE(!entry.port_list.empty());
     }
 }
+#endif
 
 // Delete mrouter port to make non-OIF entry use default group again
 
@@ -1134,9 +1139,10 @@ TEST(nas_mc, send_mrouter_del_event_1)
 }
 
 // Non-OIF entries should be changed back to link to group with no port member
-
+#if 0
 TEST(nas_mc, validate_igmp_non_oif_entry_1)
 {
+    sleep(1);
     mc_entry_list.clear();
     ASSERT_TRUE(run_command("hshell -c \"ipmc table show\"", igmp_entry_check, igmp_entry_proc));
     ASSERT_TRUE(mc_entry_list.size() > 0);
@@ -1159,6 +1165,8 @@ TEST(nas_mc, validate_mld_non_oif_entry_1)
     }
 }
 
+#endif
+
 TEST(nas_mc, send_ipv4_non_oif_route_del_event)
 {
     ASSERT_TRUE(send_mc_update_event(TEST_VID, "", TEST_GRP_IPV4, TEST_NULL_LIST,true, false, false));
@@ -1174,12 +1182,13 @@ TEST(nas_mc, send_ipv6_non_oif_route_del_event)
     ASSERT_TRUE(send_mc_update_event(TEST_VID, "", TEST_GRP_IPV6,TEST_SRC_IPV6_LIST, false, false, false));
     ASSERT_TRUE(send_mc_update_event(TEST_VID, "", TEST_GRP_IPV6_LIST,TEST_SRC_IPV6_LIST, false, false, false));
 }
-
+#if 0
 TEST(nas_mc, check_clear_intf_entries)
 {
     // Create non-OIF entry
     ASSERT_TRUE(send_mc_update_event(TEST_VID, "", TEST_GRP_IPV4, TEST_NULL_LIST,true, false, true));
     ASSERT_TRUE(send_mc_update_event(TEST_VID, "", TEST_GRP_IPV6, TEST_NULL_LIST, false, false, true));
+    sleep(1);
     mc_entry_list.clear();
     ASSERT_TRUE(run_command("hshell -c \"ipmc table show\"", igmp_entry_check, igmp_entry_proc));
     ASSERT_TRUE(run_command("hshell -c \"ipmc ip6table show\"", mld_entry_check, mld_entry_proc));
@@ -1196,6 +1205,7 @@ TEST(nas_mc, check_clear_intf_entries)
     // Add mrouter
     ASSERT_TRUE(send_mc_update_event(TEST_VID, IGMP_MROUTER_IF_NAME, TEST_NULL_LIST, TEST_NULL_LIST, true, true, true));
     ASSERT_TRUE(send_mc_update_event(TEST_VID, MLD_MROUTER_IF_NAME, TEST_NULL_LIST, TEST_NULL_LIST, false, true, true));
+    sleep(1);
     mc_entry_list.clear();
     ASSERT_TRUE(run_command("hshell -c \"ipmc table show\"", igmp_entry_check, igmp_entry_proc));
     ASSERT_TRUE(run_command("hshell -c \"ipmc ip6table show\"", mld_entry_check, mld_entry_proc));
@@ -1230,12 +1240,14 @@ TEST(nas_mc, check_clear_intf_entries)
     cout << "Delete all entries" << endl;
     ASSERT_TRUE(send_mc_update_event(TEST_VID, "", TEST_GRP_IPV4, TEST_NULL_LIST,true, false, false));
     ASSERT_TRUE(send_mc_update_event(TEST_VID, "", TEST_GRP_IPV6, TEST_NULL_LIST, false, false, false));
+    sleep(1);
     mc_entry_list.clear();
     ASSERT_TRUE(run_command("hshell -c \"ipmc ip6table show\"", mld_entry_check, mld_entry_proc));
     ASSERT_TRUE(run_command("hshell -c \"mc show\"", mc_group_check, mc_group_proc));
     dump_mc_entry_list();
     ASSERT_TRUE(mc_entry_list.empty());
 }
+#endif
 
 TEST(nas_mc, deinit_event_service)
 {

--- a/src/unit_test/nas_sflow_unittest.cpp
+++ b/src/unit_test/nas_sflow_unittest.cpp
@@ -78,8 +78,7 @@ bool nas_sflow_create_test(){
     cps_api_key_from_attr_with_qual(cps_api_object_key(obj),BASE_SFLOW_ENTRY_OBJ,
                                     cps_api_qualifier_TARGET);
 
-    unsigned int ifindex;
-    std::cin>>ifindex;
+    unsigned int ifindex = 16;
     cps_api_object_attr_add_u32(obj,BASE_SFLOW_ENTRY_IFINDEX,ifindex);
     cps_api_object_attr_add_u32(obj,BASE_SFLOW_ENTRY_DIRECTION,(BASE_CMN_TRAFFIC_PATH_t)BASE_CMN_TRAFFIC_PATH_INGRESS);
     cps_api_object_attr_add_u32(obj,BASE_SFLOW_ENTRY_SAMPLING_RATE,1);

--- a/src/unit_test/run_test
+++ b/src/unit_test/run_test
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+apt-get update
+
+apt-get install -y python-pytest
+
+/usr/bin/python -m pytest ./mac_test.py
+
 ./nas_mac_unittest
 ./nas_stg_unittest
 ./nas_sflow_unittest


### PR DESCRIPTION
* Feature: VxLAN Support
* Bugfix: Issue with port-vlan-subport delete
* Bugfix: Mac changes to support mac learned from untagged_attached vlan members and untagged
          virtual network members
* Bugfix: Add lock to handle NPU MAC events
* Update: Check for tunnel ID 0 for tunnel creation/deletion event
* Update: Handle vlan member port add to program stg state
* Update: Add Ipv6 Extended routes handle code
* Update: For non-OIF entry, restore to default group ID after mrouter port is deleted
* Update: Prevent to publish vlan id for 1d remote mac
* Update: Return code to trigger VLAN key lookup to accomadate initial case when snooping status is same
* Update: Add nas-linux and CPS library dependencies

Signed-off-by: Garrick He <garrick_he@dell.com>